### PR TITLE
get units from results

### DIFF
--- a/leadbutt.py
+++ b/leadbutt.py
@@ -142,18 +142,27 @@ def leadbutt(config_file, cli_options, verbose=False, **kwargs):
             unit = metric['Unit']
         else:
             unit = None
-        results = conn.get_metric_statistics(
-            period_local,  # minimum: 60
-            start_time,
-            end_time,
-            metric['MetricName'],  # RequestCount, CPUUtilization
-            metric['Namespace'],  # AWS/ELB, AWS/EC2
-            metric['Statistics'],  # Sum, Maximum
-            dimensions=metric['Dimensions'],
-            unit=unit,
-        )
-        # sys.stderr.write('{} {}\n'.format(options['Count'], len(results)))
-        output_results(results, metric, options)
+        # make sure that if we get one metric name, we make it a list and loop over
+        # the one value
+        metric_names = metric['MetricName']
+        if not isinstance(metric['MetricName'], list):
+            metric_names = [metric['MetricName']]
+        for metric_name in metric_names:
+            # we need a copy of the metric dict with the MetricName swapped out
+            this_metric = metric.copy()
+            this_metric['MetricName'] = metric_name
+            results = conn.get_metric_statistics(
+                period_local,  # minimum: 60
+                start_time,
+                end_time,
+                metric_name,  # RequestCount, CPUUtilization
+                metric['Namespace'],  # AWS/ELB, AWS/EC2
+                metric['Statistics'],  # Sum, Maximum
+                dimensions=metric['Dimensions'],
+                unit=unit,
+            )
+            # sys.stderr.write('{} {}\n'.format(options['Count'], len(results)))
+            output_results(results, this_metric, options)
 
 
 def main(*args, **kwargs):

--- a/leadbutt.py
+++ b/leadbutt.py
@@ -101,10 +101,10 @@ def output_results(results, metric, options):
             stat_keys = [stat_keys]
         for statistic in stat_keys:
             context['statistic'] = statistic
-            # get and then sanitize metric name
-            metric_name = (formatter % context).replace('/', '.').lower()
-            # copy the unit name from the result to the context
+            # get and then sanitize metric name, first copy the unit name from the
+            # result to the context to keep the default format happy
             context['Unit'] = result['Unit']
+            metric_name = (formatter % context).replace('/', '.').lower()
             line = '{0} {1} {2}\n'.format(
                 metric_name,
                 result[statistic],

--- a/sample_templates/rds.yml.j2
+++ b/sample_templates/rds.yml.j2
@@ -1,0 +1,29 @@
+Auth:
+  region: "{{ region }}"
+Metrics:
+{%- for rds in resources %}
+- Namespace: "AWS/RDS"
+    Dimensions:
+      DBInstanceIdentifier: "{{ rds.id }}"
+    MetricName:
+      - NetworkReceiveThroughput
+      - DiskQueueDepth
+      - ReadLatency
+      - CPUCreditUsage
+      - ReadThroughput
+      - WriteLatency
+      - CPUUtilization
+      - WriteIOPS
+      - FreeStorageSpace
+      - CPUCreditBalance
+      - FreeableMemory
+      - DatabaseConnections
+      - ReadIOPS
+      - NetworkTransmitThroughput
+      - SwapUsage
+      - WriteThroughput
+      - BinLogDiskUsage
+    Statistics:
+      - Average
+      - Maximum
+{% endfor %}

--- a/test_leadbutt.py
+++ b/test_leadbutt.py
@@ -85,6 +85,7 @@ class output_resultsTest(unittest.TestCase):
     def test_default_formatter_used(self, mock_sysout):
         mock_results = [{
             'Timestamp': datetime.datetime.utcnow(),
+            'Unit': 'Count',
             'Sum': 1337.0,
         }]
         metric = {
@@ -107,6 +108,7 @@ class output_resultsTest(unittest.TestCase):
     def test_custom_formatter_used(self, mock_sysout):
         mock_results = [{
             'Timestamp': datetime.datetime.utcnow(),
+            'Unit': 'Count',
             'Sum': 1337.0,
         }]
         metric = {
@@ -132,6 +134,7 @@ class output_resultsTest(unittest.TestCase):
             'Timestamp': datetime.datetime.utcnow(),
             'Maximum': 9001.0,
             'Average': 1337.0,
+            'Unit': 'Count',
         }]
         metric = {
             'Namespace': 'AWS/Foo',


### PR DESCRIPTION
Stock cloudwatch-to-graphite wants you to configure the units for each metric. This is un-necessary, and requires that you write a lot of config if you want several metrics that are in different units. This change allows to to not specify the units, so you get all available units (_usually_ 1 per metric) and send all to graphite.
