### PR TITLE
cli template tokens

### DIFF
--- a/plumbum.py
+++ b/plumbum.py
@@ -69,7 +69,7 @@ def get_property_func(key):
 def filter_key(filter_args):
     def filter_instance(instance):
         return all([value == get_property_func(key)(instance)
-            for key, value in filter_args.items()])
+                    for key, value in filter_args.items()])
     return filter_instance
 
 
@@ -198,7 +198,7 @@ def main():
     # base tokens
     template_tokens = {
         'filters': filters,
-        'region': region,       # Use for Auth config section if needed
+        'region': region,  # Use for Auth config section if needed
         'resources': resources,
     }
     # add tokens passed as cli args:
@@ -207,7 +207,7 @@ def main():
             (key, value) = token_pair.split('=')
             template_tokens[key] = value
 
-    print(template.render( template_tokens))
+    print(template.render(template_tokens))
 
 
 if __name__ == '__main__':

--- a/plumbum.py
+++ b/plumbum.py
@@ -208,7 +208,7 @@ def main():
     if tokens is not None:
         for token_pair in tokens:
             if token_pair.count('=') != 1:
-                raise CliArgsException("token pair '{}' invalid, must contain exactly one '=' character.".format(token_pair))
+                raise CliArgsException("token pair '{0}' invalid, must contain exactly one '=' character.".format(token_pair))
             (key, value) = token_pair.split('=')
             template_tokens[key] = value
 

--- a/plumbum.py
+++ b/plumbum.py
@@ -81,20 +81,14 @@ def lookup(instances, filter_by=None):
 
 def interpret_options(args=sys.argv[1:]):
 
-    if '--version' in args:
-        print(__version__)
-        sys.exit()
-
     parser = argparse.ArgumentParser()
+    parser.add_argument('--version', action='version', version=__version__)
     parser.add_argument("-r", "--region", help="AWS region", default=DEFAULT_REGION)
-    parser.add_argument("template", type=str,
-                        help="the template to interpret")
-    parser.add_argument("-n", "--namespace", help="AWS namespace", required=True)
     parser.add_argument("-f", "--filter", help="filter to apply to AWS objects")
+    parser.add_argument("namespace", help="AWS namespace", type=str)
+    parser.add_argument("template", type=str, help="the template to interpret")
 
     args = parser.parse_args(args=args)
-    if args.template is None:
-        sys.exit(127)
 
     # Support 'ec2' (human friendly) and 'AWS/EC2' (how CloudWatch natively calls these things)
     namespace = args.namespace.rsplit('/', 2)[-1].lower()

--- a/plumbum.py
+++ b/plumbum.py
@@ -30,7 +30,6 @@ They're written in jinja2, and have these variables available:
 from __future__ import unicode_literals
 
 import argparse
-import re
 import sys
 
 import boto

--- a/plumbum.py
+++ b/plumbum.py
@@ -50,6 +50,10 @@ __version__ = '0.9.0'
 DEFAULT_REGION = 'us-east-1'
 
 
+class CliArgsException(Exception):
+    pass
+
+
 def get_property_func(key):
     """
     Get the accessor function for an instance to look for `key`.
@@ -203,6 +207,8 @@ def main():
     # add tokens passed as cli args:
     if tokens is not None:
         for token_pair in tokens:
+            if token_pair.count('=') != 1:
+                raise CliArgsException("token pair '{}' invalid, must contain exactly one '=' character.".format(token_pair))
             (key, value) = token_pair.split('=')
             template_tokens[key] = value
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 setup(
     name='cloudwatch-to-graphite',
     description='Helper for pushing AWS CloudWatch metrics to Graphite',
-    version='0.8.1',
+    version='0.8.2',
     author='Chris Chang',
     author_email='c@crccheck.com',
     url='https://github.com/crccheck/cloudwatch-to-graphite',


### PR DESCRIPTION
Allow passing of arbitrary replacement tokens. For example, `plumbum --token account_alias=main <namespace> <template>` will replace `{{ account_alias }}` in `<template>` with `main`.
