### PR TITLE
cloudwatch api backoff

### DIFF
--- a/leadbutt.py
+++ b/leadbutt.py
@@ -120,6 +120,7 @@ def output_results(results, metric, options):
 def leadbutt(config_file, cli_options, verbose=False, **kwargs):
 
     # This function is defined in here so that the decorator can take CLI options, passed in from main()
+    # we'll re-use the interval to sleep at the bottom of the loop that calls get_metric_statistics.
     @retry(wait_exponential_multiplier=kwargs.get('interval', None),
            wait_exponential_max=kwargs.get('max_interval', None))
     def get_metric_statistics(**kwargs):

--- a/leadbutt.py
+++ b/leadbutt.py
@@ -33,7 +33,7 @@ if sys.version_info[0] >= 3:
 else:
     text_type = unicode
 
-__version__ = '0.9.0'
+__version__ = '0.9.1'
 
 
 # configuration

--- a/plumbum.py
+++ b/plumbum.py
@@ -44,7 +44,7 @@ import boto.sqs
 import jinja2
 import os.path
 
-__version__ = '0.9.0'
+__version__ = '0.9.1'
 
 # DEFAULT_NAMESPACE = 'ec2'  # TODO
 DEFAULT_REGION = 'us-east-1'

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ boto==2.38.0
 PyYAML==3.11
 docopt==0.6.2
 Jinja2==2.8
+retrying==1.3.3
 
 # tests
 tox==2.1.1

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 setup(
     name='cloudwatch-to-graphite',
     description='Helper for pushing AWS CloudWatch metrics to Graphite',
-    version='0.9.0',
+    version='0.9.1',
     author='Chris Chang',
     author_email='c@crccheck.com',
     url='https://github.com/crccheck/cloudwatch-to-graphite',

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ setup(
         'PyYAML',
         'docopt',
         'Jinja2',
+        'retrying',
     ],
     license='Apache License, Version 2.0',
     long_description=open('README.rst').read(),

--- a/tox.ini
+++ b/tox.ini
@@ -6,5 +6,6 @@ commands = {envpython} -m unittest discover
 deps =
     mock
     jinja2
+    retrying
 setenv =
     TOX_TEST_ENTRYPOINT = 1


### PR DESCRIPTION
The CloudWatch API has a limit, but as AWS won't tell me what it is, I can't validate that this change actually solves the problem at hand; it really is a test of whether I stop seeing the occasional error that the limit has been exceeded.
